### PR TITLE
remove function removeUnderlying in Voter to avoid breaking update of vote

### DIFF
--- a/src/contracts/KZA/Voter.sol
+++ b/src/contracts/KZA/Voter.sol
@@ -163,28 +163,6 @@ contract Voter is Ownable {
         emit MarketBribeCreated(_underlying, bribe);
     }
 
-    function removeUnderlying(address _underlying) external onlyOwner {
-        require(bribes[_underlying] != address(0), "assets not a voting candidate");
-        bribes[_underlying] = address(0);
-        // by now l > 0 since there is at least 1 underlying.
-        uint256 l = markets.length;
-        for (uint256 i; i < l;) {
-            if (markets[i] == _underlying) {
-                markets[l-1] = markets[i];
-                markets.pop();
-                emit MarketBribeRemoved(_underlying);
-                return;
-            }
-            unchecked {
-                ++i;
-            }
-        }
-        // only sanity check, the _underlying is certain to exist in the list
-        // if it exists in the bribes mapping and pass the initial require
-        revert();
-        
-    }
-
     function updateVoteLogic(address _newVoteLogic) external onlyOwner {
         voteLogic = IVoteLogic(_newVoteLogic);
         emit NewVoteLogic(_newVoteLogic);

--- a/test/Voter.t.sol
+++ b/test/Voter.t.sol
@@ -37,21 +37,6 @@ contract VoterTest is Test, BaseSetup {
         assertEq(voter.marketLength(), marketLength + 1);
     }
     
-    function testRemoveUnderlying() public {
-        uint256 marketLength = voter.marketLength();
-        vm.prank(GOV);
-        voter.pushUnderlying(address(bribeTokenA));
-        vm.prank(GOV);
-        voter.removeUnderlying(address(bribeTokenA));
-        assertEq(voter.marketLength(), marketLength);
-    }
-
-    function testRemoveUnderlyingNonExistent() public {
-        uint256 marketLength = voter.marketLength();
-        vm.prank(GOV);
-        vm.expectRevert("assets not a voting candidate");
-        voter.removeUnderlying(address(bribeTokenA));
-    }
 
     function testUpdateVoteLogic() public {
         address _newVoteLogic = address(0);


### PR DESCRIPTION
remove function removeUnderlying in Voter to avoid breaking update of vote

After internal discussion, we have decided to remove this function `removeUnderlying`; since the minter only references the latest list of "reserve" asset for emission from the pool contract. A market would not be counted anyway if it is delisted from the lending pool. So user can still vote/devote on this pool and this voting wont have any material impacts on the emission of $KZA.

https://github.com/Kinza-Finance/KZA-1.0/issues/1
https://github.com/Kinza-Finance/KZA-1.0/issues/2
https://github.com/Kinza-Finance/KZA-1.0/issues/3 