### PR TITLE
remove redundant function content and unused modifier

### DIFF
--- a/src/contracts/KZA/AggregateBribe.sol
+++ b/src/contracts/KZA/AggregateBribe.sol
@@ -113,9 +113,7 @@ contract AggregateBribe {
     /// @param timestamp timestamp in second
     /// @return return the start of an epoch for that timestamp
     function getEpochStart(uint timestamp) public pure returns (uint) {
-        uint bribeStart = _bribeStart(timestamp);
-        uint bribeEnd = bribeStart + DURATION;
-        return timestamp < bribeEnd ? bribeStart : bribeStart + DURATION;
+        return _bribeStart(timestamp);
     }
 
     /// @notice Determine the prior balance for an account as of a block number

--- a/src/contracts/KZA/Voter.sol
+++ b/src/contracts/KZA/Voter.sol
@@ -106,12 +106,6 @@ contract Voter is Ownable {
         _;
     }
 
-    modifier onlyNewEpoch(address _xTokenHolder) {
-        // ensure new epoch since last vote 
-        require((block.timestamp / DURATION) * DURATION > lastVoted[_xTokenHolder], "holder already voted in this epoch");
-        _;
-    }
-
     modifier onlyEpochSynced() {
         require(block.timestamp / DURATION == epoch, "epoch out of sync; please update epoch on Minter");
         _;


### PR DESCRIPTION
remove unused modifier onlyNewEpoch;
remove unnecessary logic in getBribeStart. The function is kept though to minimize the line of code changes as well as keep compatibility with similar ve(3,3) protocols.

SafeMath in XKZA is still kept to reduce number of line to change, which should be fine maybe just not so neat.

https://github.com/Kinza-Finance/KZA-1.0/issues/16