### PR TITLE
add zeroAddressCheck except updateDelegate which can be used to unset delegate

### DIFF
--- a/src/contracts/KZA/BribeAssetRegistry.sol
+++ b/src/contracts/KZA/BribeAssetRegistry.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.17;
 
 import "@openzeppelin/access/Ownable.sol";
 
+import '../../libraries/UtilLib.sol';
 // | |/ /_ _| \ | |__  /  / \   
 // | ' / | ||  \| | / /  / _ \  
 // | . \ | || |\  |/ /_ / ___ \ 
@@ -20,6 +21,7 @@ contract BribeAssetRegistry is Ownable {
     event RemoveWhitelistAsset(address indexed asset);
 
     constructor(address _governance) {
+        UtilLib.checkNonZeroAddress(_governance);
         transferOwnership(_governance);
     }
 

--- a/src/contracts/KZA/KZA.sol
+++ b/src/contracts/KZA/KZA.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.17;
 
 import {ERC20, ERC20Permit} from "@openzeppelin/token/ERC20/extensions/draft-ERC20Permit.sol";
+import '../../libraries/UtilLib.sol';
 
 // | |/ /_ _| \ | |__  /  / \   
 // | ' / | ||  \| | / /  / _ \  
@@ -61,12 +62,14 @@ contract KZA is ERC20("KINZA", "KZA"), ERC20Permit("KINZA") {
                             CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
     constructor(address _governance) {
+        UtilLib.checkNonZeroAddress(_governance);
         governance = _governance;
     }
 
     /// @notice governance can use this to propose/cancel newGovernance.
     /// @param _newGovernace new governance
     function proposeNewGovernance(address _newGovernace) onlyGov external {
+      UtilLib.checkNonZeroAddress(_newGovernace);
       newGovernanceProposedTime = block.timestamp;
       newGovernance = _newGovernace;
       emit NewGovernanceProposal(_newGovernace);
@@ -83,6 +86,7 @@ contract KZA is ERC20("KINZA", "KZA"), ERC20Permit("KINZA") {
     /// @notice governance can use this to update bribe minter contracts
     /// @param _minter new minter
     function setBribeMinter(address _minter) onlyGov external {
+        UtilLib.checkNonZeroAddress(_minter);
         minter = _minter;
         emit NewBribeMinter(_minter);
     }

--- a/src/contracts/KZA/KZADistributor.sol
+++ b/src/contracts/KZA/KZADistributor.sol
@@ -11,6 +11,7 @@ import "../../interfaces/IPool.sol";
 import "../../interfaces/IVault.sol";
 import "../../libraries/DataTypes.sol";
 
+import '../../libraries/UtilLib.sol';
 
 
 // | |/ /_ _| \ | |__  /  / \   
@@ -53,6 +54,10 @@ contract KZADistributor is Ownable {
     event NewVariableDebtTokenRatio(uint256 newVariableDebtTokenRatio);
 
     constructor(address _governance, address _reward, address _minter, address _pool) {
+        UtilLib.checkNonZeroAddress(_governance);
+        UtilLib.checkNonZeroAddress(_reward);
+        UtilLib.checkNonZeroAddress(_minter);
+        UtilLib.checkNonZeroAddress(_pool);
         transferOwnership(_governance);
         REWARD = IERC20(_reward);
         minter = _minter;
@@ -91,6 +96,7 @@ contract KZADistributor is Ownable {
     /// @notice vault holds escrow of the reward token
     /// @param _newVault address of the new vault
     function setVault(address _newVault) external onlyOwner {
+        UtilLib.checkNonZeroAddress(_newVault);
         address oldVault = vault;
         vault = _newVault;
         emit NewVault(oldVault, _newVault);
@@ -99,6 +105,7 @@ contract KZADistributor is Ownable {
     /// @notice emissionManager is where a/dToken holder can claim reward
     /// @param _newEmissionManager address of the new emissionManager
     function setEmissionManager(address _newEmissionManager) external onlyOwner {
+        UtilLib.checkNonZeroAddress(_newEmissionManager);
         address oldmanager = address(emisisonManager);
         emisisonManager = IEmissionManager(_newEmissionManager);
         emit NewVault(oldmanager, _newEmissionManager);

--- a/src/contracts/KZA/Minter.sol
+++ b/src/contracts/KZA/Minter.sol
@@ -9,6 +9,7 @@ import "../../interfaces/IDistributor.sol";
 import "../../interfaces/IKZA.sol";
 import "../../interfaces/IPool.sol";
 
+import '../../libraries/UtilLib.sol';
 // | |/ /_ _| \ | |__  /  / \   
 // | ' / | ||  \| | / /  / _ \  
 // | . \ | || |\  |/ /_ / ___ \ 
@@ -63,6 +64,9 @@ contract Minter is Ownable {
         address _KZA,
         address _governance
     ) {
+        UtilLib.checkNonZeroAddress(_pool);
+        UtilLib.checkNonZeroAddress(_KZA);
+        UtilLib.checkNonZeroAddress(_governance);
         pool = IPool(_pool);
         KZA = IKZA(_KZA);
         epoch = block.timestamp / WEEK;
@@ -73,6 +77,7 @@ contract Minter is Ownable {
     /// @param _newVoter the voter address that determines the allocation 
     ///        of each mint
     function updateVoter(address _newVoter) external onlyOwner {
+        UtilLib.checkNonZeroAddress(_newVoter);
         voter = IVoter(_newVoter);
         emit NewVoter(_newVoter);
     }
@@ -88,6 +93,7 @@ contract Minter is Ownable {
     /// @notice gov can update distributor 
     /// @param _newDistributor distributor can pull the emission out
     function updateDistributor(address _newDistributor) external onlyOwner {
+        UtilLib.checkNonZeroAddress(_newDistributor);
         distributor = _newDistributor;
         emit NewDistributor(_newDistributor);
     }

--- a/src/contracts/KZA/VestingEscrow.sol
+++ b/src/contracts/KZA/VestingEscrow.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/access/Ownable.sol";
 
 import "../../interfaces/IKZA.sol";
 
+import '../../libraries/UtilLib.sol';
 // | |/ /_ _| \ | |__  /  / \   
 // | ' / | ||  \| | / /  / _ \  
 // | . \ | || |\  |/ /_ / ___ \ 
@@ -74,6 +75,8 @@ contract VestingEscrow is Ownable {
                           CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
     constructor(address _kza, address _gov) {
+        UtilLib.checkNonZeroAddress(_kza);
+        UtilLib.checkNonZeroAddress(_gov);
         KZA = IKZA(_kza);
         transferOwnership(_gov);
     }

--- a/src/contracts/KZA/VoteLogic.sol
+++ b/src/contracts/KZA/VoteLogic.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 import "@openzeppelin/access/Ownable.sol";
 import "../../interfaces/IXToken.sol";
 
+import '../../libraries/UtilLib.sol';
 // | |/ /_ _| \ | |__  /  / \   
 // | ' / | ||  \| | / /  / _ \  
 // | . \ | || |\  |/ /_ / ___ \ 
@@ -39,6 +40,8 @@ contract VoteLogic is Ownable {
         address _xKZA,
         address _governance
     ) {
+        UtilLib.checkNonZeroAddress(_xKZA);
+        UtilLib.checkNonZeroAddress(_governance);
         XToken = IXToken(_xKZA);
         transferOwnership(_governance);
 

--- a/src/contracts/KZA/Voter.sol
+++ b/src/contracts/KZA/Voter.sol
@@ -7,6 +7,7 @@ import '../../interfaces/IVoteLogic.sol';
 import '../../interfaces/IBribe.sol';
 import './AggregateBribe.sol';
 
+import '../../libraries/UtilLib.sol';
 // | |/ /_ _| \ | |__  /  / \   
 // | ' / | ||  \| | / /  / _ \  
 // | . \ | || |\  |/ /_ / ___ \ 
@@ -120,6 +121,11 @@ contract Voter is Ownable {
                             CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
     constructor(address _xToken, address _minter, address _voteLogic, address  _bribeAssetRegistry, address _governance) {
+        UtilLib.checkNonZeroAddress(_xToken);
+        UtilLib.checkNonZeroAddress(_minter);
+        UtilLib.checkNonZeroAddress(_voteLogic);
+        UtilLib.checkNonZeroAddress(_bribeAssetRegistry);
+        UtilLib.checkNonZeroAddress(_governance);
         xToken = _xToken;
         minter = _minter;
         voteLogic = IVoteLogic(_voteLogic);

--- a/src/contracts/KZA/XKZA.sol
+++ b/src/contracts/KZA/XKZA.sol
@@ -12,6 +12,8 @@ import "@openzeppelin/utils/Address.sol";
 import "../../interfaces/IKZA.sol";
 import "../../interfaces/IVoter.sol";
 
+import '../../libraries/UtilLib.sol';
+
 // | |/ /_ _| \ | |__  /  / \   
 // | ' / | ||  \| | / /  / _ \  
 // | . \ | || |\  |/ /_ / ___ \ 
@@ -102,6 +104,8 @@ contract XKZA is Ownable, ReentrancyGuard, ERC20("escrowed Kinza Token", "xKZA")
                           CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
     constructor(address _KZA, address _governance) {
+      UtilLib.checkNonZeroAddress(_KZA);
+      UtilLib.checkNonZeroAddress(_governance);
       KZA = IKZA(_KZA);
       _transferWhitelist.add(address(this));
       transferOwnership(_governance);
@@ -178,6 +182,7 @@ contract XKZA is Ownable, ReentrancyGuard, ERC20("escrowed Kinza Token", "xKZA")
 
     /// @param _newVoter new voter contract
     function updateVoter(address _newVoter) external onlyOwner {
+      UtilLib.checkNonZeroAddress(_newVoter);
       voter = IVoter(_newVoter);
       emit NewVoter(_newVoter);
     }

--- a/src/contracts/integration/LockTransferStrategy.sol
+++ b/src/contracts/integration/LockTransferStrategy.sol
@@ -5,6 +5,7 @@ import {TransferStrategyBase} from './TransferStrategyBase.sol';
 import {SafeERC20} from '@openzeppelin/token/ERC20/utils/SafeERC20.sol';
 import {IERC20} from '@openzeppelin/token/ERC20/IERC20.sol';
 import "../../interfaces/IKZA.sol";
+import '../../libraries/UtilLib.sol';
 
 // | |/ /_ _| \ | |__  /  / \   
 // | ' / | ||  \| | / /  / _ \  
@@ -41,6 +42,10 @@ contract LockTransferStrategy is TransferStrategyBase {
       address rewardsVault,
       address xkza
     ) TransferStrategyBase(incentivesController, gov) {
+      UtilLib.checkNonZeroAddress(incentivesController);
+      UtilLib.checkNonZeroAddress(gov);
+      UtilLib.checkNonZeroAddress(rewardsVault);
+      UtilLib.checkNonZeroAddress(xkza);
       REWARDS_VAULT = rewardsVault;
       XKZA = IKZA(xkza);
       KZA = XKZA.KZA();

--- a/src/contracts/integration/ReserveFeeDistributor.sol
+++ b/src/contracts/integration/ReserveFeeDistributor.sol
@@ -10,6 +10,7 @@ import "../../interfaces/IBribe.sol";
 import "../../interfaces/IVoter.sol";
 import "../../interfaces/IPool.sol";
 
+import '../../libraries/UtilLib.sol';
 // | |/ /_ _| \ | |__  /  / \   
 // | ' / | ||  \| | / /  / _ \  
 // | . \ | || |\  |/ /_ / ___ \ 
@@ -37,6 +38,10 @@ contract ReserveFeeDistributor is Ownable {
     
 
     constructor(address _governance, address _treasury, address _pool, address _voter) {
+        UtilLib.checkNonZeroAddress(_governance);
+        UtilLib.checkNonZeroAddress(_treasury);
+        UtilLib.checkNonZeroAddress(_pool);
+        UtilLib.checkNonZeroAddress(_voter);
         transferOwnership(_governance);
         treasury = _treasury;
         pool = IPool(_pool);

--- a/src/contracts/integration/RewardsVault.sol
+++ b/src/contracts/integration/RewardsVault.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 import "@openzeppelin/access/Ownable.sol";
 import "../../interfaces/IKZA.sol";
 
+import '../../libraries/UtilLib.sol';
 // | |/ /_ _| \ | |__  /  / \   
 // | ' / | ||  \| | / /  / _ \  
 // | . \ | || |\  |/ /_ / ___ \ 
@@ -24,6 +25,9 @@ contract RewardsVault is Ownable {
     event NewTransferStrat(address oldTransferStrategy, address newTransferStrategy);
 
     constructor(address _governance, address _distributor, address _reward) {
+        UtilLib.checkNonZeroAddress(_governance);
+        UtilLib.checkNonZeroAddress(_distributor);
+        UtilLib.checkNonZeroAddress(_reward);
         transferOwnership(_governance);
         REWARD = IKZA(_reward);
         distributor = _distributor;

--- a/src/libraries/UtilLib.sol
+++ b/src/libraries/UtilLib.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.17;
+
+library UtilLib {
+    error ZeroAddress();
+    function checkNonZeroAddress(address _address) internal pure {
+        if (_address == address(0)) revert ZeroAddress();
+    }
+}

--- a/test/EmissionDistributor.t.sol
+++ b/test/EmissionDistributor.t.sol
@@ -8,7 +8,7 @@ contract KZADistributorTest is Test, BaseSetup {
     function testSetVault() public {
         vm.prank(GOV);
         // it takes 0 too, but implies notifyReward would be paused
-        address newVault;
+        address newVault = address(1);
         dist.setVault(newVault);
         assertEq(address(dist.vault()), newVault);
     }
@@ -21,7 +21,7 @@ contract KZADistributorTest is Test, BaseSetup {
     }
 
     function testSetEmissionManager() public {
-        address newEmissionManager;
+        address newEmissionManager = address(1);
         vm.prank(GOV);
         dist.setEmissionManager(newEmissionManager);
         assertEq(address(dist.emisisonManager()), newEmissionManager);


### PR DESCRIPTION

add zeroAddressCheck to all relevant contracts including all mentioned in the issues and more.

- zeroAddressCheck is not added to updateDelegate, which can be used to unset delegate (by setting to address(0))

https://github.com/Kinza-Finance/KZA-1.0/issues/9