### PR TITLE
use local variable instead of repeated retrieval of storage to reduce gas

### DIFF
--- a/src/contracts/KZA/KZA.sol
+++ b/src/contracts/KZA/KZA.sol
@@ -78,8 +78,9 @@ contract KZA is ERC20("KINZA", "KZA"), ERC20Permit("KINZA") {
     /// @notice newGovernance need to accept the governance role
     function acceptNewGovernance() onlyNewGov external {
       require(block.timestamp > governanceDelay + newGovernanceProposedTime, "pending governance delay");
-      emit NewGovernance(governance, newGovernance);
-      governance = newGovernance;
+      address _newGovernace = newGovernance;
+      emit NewGovernance(governance, _newGovernace);
+      governance = _newGovernace;
       newGovernance = address(0);
     }
 

--- a/src/contracts/KZA/Minter.sol
+++ b/src/contracts/KZA/Minter.sol
@@ -108,9 +108,10 @@ contract Minter is Ownable {
         require(address(voter) != address(0), "voter needs to be set");
         require(current > lastEpoch, "only trigger each new week"); 
         epoch = current;
-        KZA.mint(address(this), emission);
-        uint256 prevEmission = emission;
-        emission = (emission * (PRECISION - decay)) / PRECISION;
+        uint256 _emission = emission;
+        uint256 prevEmission = _emission;
+        KZA.mint(address(this), _emission);
+        emission = (_emission * (PRECISION - decay)) / PRECISION;
         // get the scheduled total
         address[] memory reserves = getReserves();
         uint256 length = reserves.length;

--- a/src/contracts/KZA/XKZA.sol
+++ b/src/contracts/KZA/XKZA.sol
@@ -276,10 +276,10 @@ contract XKZA is Ownable, ReentrancyGuard, ERC20("escrowed Kinza Token", "xKZA")
     function finalizeRedeem(uint256 redeemIndex) external nonReentrant validateRedeem(msg.sender, redeemIndex) {
       RedeemInfo storage _redeem = userRedeems[msg.sender][redeemIndex];
       require(_currentBlockTimestamp() >= _redeem.endTime, "finalizeRedeem: vesting duration has not ended yet");
-
+      uint256 xAmount = _redeem.xAmount;
       // remove from SBT total
-      userReedemTotal[msg.sender] -= _redeem.xAmount;
-      _finalizeRedeem(msg.sender, _redeem.xAmount, _redeem.amount);
+      userReedemTotal[msg.sender] -= xAmount;
+      _finalizeRedeem(msg.sender, xAmount, _redeem.amount);
 
       // remove redeem entry
       _deleteRedeemEntry(redeemIndex);
@@ -297,9 +297,10 @@ contract XKZA is Ownable, ReentrancyGuard, ERC20("escrowed Kinza Token", "xKZA")
     function cancelRedeem(uint256 redeemIndex) external nonReentrant validateRedeem(msg.sender, redeemIndex) {
       RedeemInfo storage _redeem = userRedeems[msg.sender][redeemIndex];
 
+      uint256 xAmount = _redeem.xAmount;
       // make redeeming xKZA available again
-      userReedemTotal[msg.sender] -= _redeem.xAmount;
-      _transfer(address(this), msg.sender, _redeem.xAmount);
+      userReedemTotal[msg.sender] -= xAmount;
+      _transfer(address(this), msg.sender, xAmount);
 
       if (address(voter) != address(0)) {
         uint256 before = KZA.balanceOf(address(this));
@@ -309,7 +310,7 @@ contract XKZA is Ownable, ReentrancyGuard, ERC20("escrowed Kinza Token", "xKZA")
         require(before == KZA.balanceOf(address(this)), "voter creates difference in locked token");
       }
 
-      emit CancelRedeem(msg.sender, _redeem.xAmount);
+      emit CancelRedeem(msg.sender, xAmount);
 
       // remove redeem entry
       _deleteRedeemEntry(redeemIndex);


### PR DESCRIPTION
use local variable instead of repeated retrieval of storage to reduce gas. Fixed all reported cases except two funcs mentioned separately on the comment in the issue page

https://github.com/Kinza-Finance/KZA-1.0/issues/10